### PR TITLE
Convert RGB888 to RGB565 for better screen handling on the esp(ST7789)

### DIFF
--- a/src/com/cover/SendImage.java
+++ b/src/com/cover/SendImage.java
@@ -1,18 +1,16 @@
 package com.cover;
 
-import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import javax.imageio.ImageIO;
 import java.util.zip.CRC32;
+import javax.imageio.ImageIO;
 
 public class SendImage {
     public void sendImage(String in, String out) {
         try {
             BufferedImage image = ImageIO.read(new File(in));
-            //int[][] hexArray = new int[240][240];
             FileOutputStream fos = new FileOutputStream(out, false);
             CRC32 crc = new CRC32();
 
@@ -20,12 +18,25 @@ public class SendImage {
             for (int y = 0; y < 240; y++) {
                 for (int x = 0; x < 240; x++) {
                     int rgb = image.getRGB(x, y);
-                    Color color = new Color(rgb);
+
+
+                    int red = (rgb >> 16) & 0xFF; 
+                    int green = (rgb >> 8) & 0xFF; 
+                    int blue = rgb & 0xFF;        
                     
-                    fos.write(color.getRed());
-                    fos.write(color.getGreen());
-                    fos.write(color.getBlue());
-                    crc.update(color.getRed() + color.getGreen() + color.getBlue());
+                    int red5 = (red >> 3) & 0x1F;    // 5 bits
+                    int green6 = (green >> 2) & 0x3F; // 6 bits
+                    int blue5 = (blue >> 3) & 0x1F;   // 5 bits
+                    
+                    int rgb565 = (red5 << 11) | (green6 << 5) | blue5;
+                    
+                    // little endian important
+                    fos.write(rgb565 & 0xFF);       
+                    fos.write((rgb565 >> 8) & 0xFF);
+
+                    // Update CRC
+                    crc.update((rgb565 >> 8) & 0xFF);
+                    crc.update(rgb565 & 0xFF);
              }
             }
             //  write crc to file as int in 4 bytes please


### PR DESCRIPTION
This code will provide way better result in term of size and compatibility. 

Colors will now match what the screens ask (RGB565)